### PR TITLE
Use Jasmine method to set default timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+## Upcoming
+
+- Use Jasmine's built in method to set default timeout
+
 ## 1.3.0
 
 - Unmock `Date.now()` by default

--- a/index.js
+++ b/index.js
@@ -11,9 +11,6 @@ function waitsForPromise (fn, timeout) {
 }
 
 const names = ['beforeEach', 'afterEach', 'xit', 'it', 'fit', 'ffit', 'fffit']
-const defaultOptions = {
-  timeout: 10 * 1000,
-}
 
 // Jasmine 1.3.x has no sane way of resetting to native clocks, and since we're
 // gonna test promises and such, we're gonna need it
@@ -32,6 +29,9 @@ beforeEach(function() {
   jasmine.unspy(Date, 'now')
 })
 
+// The default timeout of 6 seconds is quite often too slow, bump it to 10 seconds
+jasmine.getEnv().defaultTimeoutInterval = 10 * 1000;
+
 module.exports.patch = function patch(name) {
   return function(arg1, arg2, arg3) {
     const callback = typeof arg1 === 'function' ? arg1 : arg2
@@ -43,7 +43,7 @@ module.exports.patch = function patch(name) {
       optionsArg = arg3
     }
 
-    const options = Object.assign({}, defaultOptions, optionsArg)
+    const options = Object.assign({}, optionsArg)
 
     const middleware = function() {
       const value = callback()

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -1,6 +1,6 @@
 'use babel'
 
-import { it as myIt, xit as myXit, wait, beforeEach } from '../'
+import { it as myIt, xit as myXIt, wait, beforeEach } from '../'
 
 describe('Jasmine-Fix', function() {
   describe('it', function() {
@@ -76,11 +76,11 @@ describe('Jasmine-Fix', function() {
   })
 
   describe('timeouts', function() {
-    myXit("uses a default timeout of 10 seconds when none is provided", async function() {
-      await wait(10001)
+    myIt('uses a default timeout of 10 seconds when none is provided', async function() {
+      await wait(20 * 1000)
     })
-    myXit("uses a custom timeout when provided", async function() {
-      await wait(20001)
+    myXIt('uses a custom timeout when provided', async function() {
+      await wait(10 * 1000)
     }, {
       timeout: 2000,
     })


### PR DESCRIPTION
Instead of sending an explicit timeout of 10 seconds on each call, use Jasmine's own method to set the default timeout to 10 seconds. This allows specs of projects using `jasmine-fix` to use the same method to set the default timeout globally in one place instead of having to explicitly send in their own override timeout.

Manually tested the timeout specs:
![image](https://user-images.githubusercontent.com/427137/30719730-7cafdf9c-9ed9-11e7-892a-edb99aaa9315.png)